### PR TITLE
Update to 2-4-stable branch

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,11 @@ group :assets do
 end
 
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', :branch => "2-3-stable"
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', :branch => "2-4-stable"
 
 # Provides basic frontend and backend functionalities for testing purposes
-gem 'spree_backend', '~> 2.3'
-gem 'spree_frontend', '~> 2.3'
+gem 'spree_backend', '~> 2.4'
+gem 'spree_frontend', '~> 2.4'
 
 group :test do
   gem 'shoulda-matchers'

--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,11 @@ group :assets do
 end
 
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', :branch => "2-2-stable"
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise', :branch => "2-3-stable"
 
 # Provides basic frontend and backend functionalities for testing purposes
-gem 'spree_backend', '~> 2.2'
-gem 'spree_frontend', '~> 2.2'
+gem 'spree_backend', '~> 2.3'
+gem 'spree_frontend', '~> 2.3'
 
 group :test do
   gem 'shoulda-matchers'
@@ -20,7 +20,7 @@ group :test do
   gem 'database_cleaner'
   gem 'factory_girl', '~> 4.2'
   gem 'ffaker'
-  gem 'rspec-rails',  '~> 2.13'
+  #gem 'rspec-rails',  '~> 2.13'
   gem 'simplecov'
   gem 'selenium-webdriver'
   gem 'stripe-ruby-mock', '1.10.1.2'

--- a/app/models/concerns/spree/recurring/stripe_recurring/api_handler.rb
+++ b/app/models/concerns/spree/recurring/stripe_recurring/api_handler.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Recurring < ActiveRecord::Base
+  class Recurring < Spree::Base
     class StripeRecurring < Spree::Recurring
       module ApiHandler
         extend ActiveSupport::Concern

--- a/app/models/concerns/spree/recurring/stripe_recurring/api_handler/plan_api_handler.rb
+++ b/app/models/concerns/spree/recurring/stripe_recurring/api_handler/plan_api_handler.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Recurring < ActiveRecord::Base
+  class Recurring < Spree::Base
     class StripeRecurring < Spree::Recurring
       module ApiHandler 
         module PlanApiHandler

--- a/app/models/concerns/spree/recurring/stripe_recurring/api_handler/subscription_api_handler.rb
+++ b/app/models/concerns/spree/recurring/stripe_recurring/api_handler/subscription_api_handler.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Recurring < ActiveRecord::Base
+  class Recurring < Spree::Base
     class StripeRecurring < Spree::Recurring
       module ApiHandler
         module SubscriptionApiHandler

--- a/app/models/concerns/spree/recurring/stripe_recurring/api_handler/subscription_event_api_handler.rb
+++ b/app/models/concerns/spree/recurring/stripe_recurring/api_handler/subscription_event_api_handler.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Recurring < ActiveRecord::Base
+  class Recurring < Spree::Base
     class StripeRecurring < Spree::Recurring
       module ApiHandler
         module SubscriptionEventApiHandler

--- a/app/models/spree/recurring.rb
+++ b/app/models/spree/recurring.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Recurring < ActiveRecord::Base
+  class Recurring < Spree::Base
     include RestrictiveDestroyer
 
     acts_as_restrictive_destroyer

--- a/app/models/spree/recurring/stripe_recurring.rb
+++ b/app/models/spree/recurring/stripe_recurring.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Recurring < ActiveRecord::Base
+  class Recurring < Spree::Base
     class StripeRecurring < Recurring
       include ApiHandler
 

--- a/db/migrate/20141218173349_add_preference_to_spree_recurring.rb
+++ b/db/migrate/20141218173349_add_preference_to_spree_recurring.rb
@@ -1,0 +1,5 @@
+class AddPreferenceToSpreeRecurring < ActiveRecord::Migration
+  def change
+    add_column :spree_recurrings, :preferences, :text
+  end
+end

--- a/spec/models/spree/recurring_spec.rb
+++ b/spec/models/spree/recurring_spec.rb
@@ -8,6 +8,8 @@ describe Spree::Recurring do
   it { should validate_presence_of :type }
   it { should validate_presence_of :name }
   it { should validate_uniqueness_of(:type).with_message('of provider recurring already exists') }
+  it { is_expected.to have_attribute (:description) }
+  it { is_expected.to have_attribute (:preferences) }
 
   describe 'preferences' do
     describe 'secret_key' do
@@ -125,7 +127,7 @@ describe Spree::Recurring do
           recurring.preferred_secret_key = 'preferred_secret_key'
         end
 
-        it { recurring.has_preferred_keys?.should be_true }
+        it { recurring.has_preferred_keys?.should be true }
       end
 
       context 'when preferred_secret_key is not set' do
@@ -133,7 +135,7 @@ describe Spree::Recurring do
           recurring.preferred_secret_key = ''
         end
 
-        it { recurring.has_preferred_keys?.should be_false }
+        it { recurring.has_preferred_keys?.should be false }
       end
     end
 
@@ -147,7 +149,7 @@ describe Spree::Recurring do
           recurring.preferred_secret_key = 'preferred_secret_key'
         end
 
-        it { recurring.has_preferred_keys?.should be_false }
+        it { recurring.has_preferred_keys?.should be false }
       end
 
       context 'when preferred_secret_key is not set' do
@@ -155,7 +157,7 @@ describe Spree::Recurring do
           recurring.preferred_secret_key = ''
         end
 
-        it { recurring.has_preferred_keys?.should be_false }
+        it { recurring.has_preferred_keys?.should be false }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,7 +70,7 @@ RSpec.configure do |config|
 
   # Before each spec check if it is a Javascript test and switch between using database transactions or not where necessary.
   config.before :each do
-    DatabaseCleaner.strategy = example.metadata[:js] ? :truncation : :transaction
+    DatabaseCleaner.strategy = RSpec.current_example.metadata[:js] ? :truncation : :transaction
     DatabaseCleaner.start
   end
 
@@ -80,4 +80,7 @@ RSpec.configure do |config|
   end
 
   config.fail_fast = ENV['FAIL_FAST'] || false
+  
+  # Remove rspec-rails 3 deprecation warning
+  config.infer_spec_type_from_file_location!
 end

--- a/spree_account_recurring.gemspec
+++ b/spree_account_recurring.gemspec
@@ -2,7 +2,7 @@
 Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.name        = 'spree_account_recurring'
-  s.version     = '1.1.3'
+  s.version     = '1.1.5'
   s.summary     = 'Spree extension to manage recurring payments/subscriptions using Stripe Payment Gateway.'
   s.description = s.summary
   s.required_ruby_version = '>= 1.9.3'
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.2'
+  s.add_dependency 'spree_core', '~> 2.3'
   s.add_dependency 'stripe', '1.10.1'
   s.add_dependency 'stripe_tester'
 

--- a/spree_account_recurring.gemspec
+++ b/spree_account_recurring.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   s.add_dependency 'spree_core', '~> 2.4'
-  s.add_dependency 'stripe', '1.10.1'
+  s.add_dependency 'stripe', '1.16.0'
   s.add_dependency 'stripe_tester'
 
   s.add_development_dependency 'rspec-rails',  '~> 2.13'

--- a/spree_account_recurring.gemspec
+++ b/spree_account_recurring.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.3'
+  s.add_dependency 'spree_core', '~> 2.4'
   s.add_dependency 'stripe', '1.10.1'
   s.add_dependency 'stripe_tester'
 


### PR DESCRIPTION
Hi,
I've created this pull request to update this gem to Spree **2-4-stable** branch and the Stripe gem to **1.16.0** version .

## List of changes:
* changed some base class from ActiveRecord::Base to Spree::Base , a child of ActiveRecord::Base that contains preferences hash itself
* added migration
* added presence test
* removed rspec-rails from Gemfile because of a warning about duplicate gem
* changes in `recurring_spec.rb` and in `spec_helper.rb` to remove deprecation warnings

Other tests are welcome!

Thank you for this gem !!