### PR TITLE
trying to fix dependencies for Spree bleeding edge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,11 +8,12 @@ group :assets do
 end
 
 # Provides basic authentication functionality for testing parts of your engine
-gem 'spree_auth_devise', github: 'spree/spree_auth_devise', :branch => "2-4-stable"
+gem 'spree_auth_devise', github: 'spree/spree_auth_devise'
 
 # Provides basic frontend and backend functionalities for testing purposes
-gem 'spree_backend', '~> 2.4'
-gem 'spree_frontend', '~> 2.4'
+gem 'spree_backend'
+gem 'spree_frontend'
+gem 'spree', github: 'spree/spree'
 
 group :test do
   gem 'shoulda-matchers'

--- a/spree_account_recurring.gemspec
+++ b/spree_account_recurring.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
   s.requirements << 'none'
 
-  s.add_dependency 'spree_core', '~> 2.4'
+  s.add_dependency 'spree_core'
   s.add_dependency 'stripe', '1.16.0'
   s.add_dependency 'stripe_tester'
 


### PR DESCRIPTION
I tried to resolve the dependencies to get this gem working for the newest version of Spree (3.1.0).  I don't think it's actually working properly though as I'm not getting the "Recuring" link in the "configurations" tab of the admin section after installing.

Perhaps you can take a look to update this for the newest Spree version?

Thanks!